### PR TITLE
Feature/#47/chat

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,6 +65,7 @@ dependencies {
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-firestore-ktx'
     implementation 'com.google.firebase:firebase-storage-ktx'
+    implementation 'com.google.firebase:firebase-messaging:17.1.0'
 
     implementation 'com.google.code.gson:gson:2.8.9'
     implementation 'com.github.bumptech.glide:glide:4.13.2'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,8 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET" />
 
+
+
     <uses-feature
         android:name="android.hardware.camera"
         android:required="false" />
@@ -45,6 +47,15 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/external" />
         </provider>
+
+        <service
+            android:name=".service.MyFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/wapapp2/dummy/DummyData.kt
+++ b/app/src/main/java/com/example/wapapp2/dummy/DummyData.kt
@@ -28,20 +28,10 @@ class DummyData {
 
             // test data
             val testList = ArrayList<ChatDTO>()
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "안녕하세요", ""))
+            testList.add(ChatDTO(peopleList[0].userName,  Date(), "안녕하세요", peopleList[0].userId))
 
-            testList.add(ChatDTO(peopleList[1].userName, peopleList[1].userId, Date(), "네!! 안녕하세요!", ""))
-            testList.add(ChatDTO(peopleList[2].userName, peopleList[2].userId, Date(), "네!! 안녕하세요.", ""))
-            testList.add(ChatDTO(peopleList[2].userName, peopleList[2].userId, Date(), "~~", ""))
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "!", ""))
-            testList.add(ChatDTO(peopleList[1].userName, peopleList[1].userId, Date(), "@@", ""))
-            testList.add(ChatDTO(peopleList[2].userName, peopleList[2].userId, Date(), "@@", ""))
-            testList.add(ChatDTO(peopleList[1].userName, peopleList[1].userId, Date(), "@@", ""))
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "1", ""))
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "2", ""))
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "3", ""))
-            testList.add(ChatDTO(peopleList[0].userName, peopleList[0].userId, Date(), "4", ""))
-
+            testList.add(ChatDTO(peopleList[1].userName,  Date(), "네!! 안녕하세요!", peopleList[1].userId))
+            testList.add(ChatDTO(peopleList[2].userName,  Date(), "네!! 안녕하세요.", peopleList[2].userId))
 
             return testList
         }

--- a/app/src/main/java/com/example/wapapp2/dummy/TestLogics.kt
+++ b/app/src/main/java/com/example/wapapp2/dummy/TestLogics.kt
@@ -21,7 +21,7 @@ class TestLogics private constructor() {
 
         fun notifyChatNotification(context: Context) {
             val helper = ChatNotificationHelper.getINSTANCE(context)
-            helper.notifyNotification(context, "정산1", ChatDTO("남진화", "0", Date(), "반갑습니다!", ""))
+            helper.notifyNotification(context, "정산1", ChatDTO("남진화", Date(), "반갑습니다!", "0"))
         }
 
         fun notifyReceiptNotification(context: Context) {

--- a/app/src/main/java/com/example/wapapp2/model/ChatDTO.kt
+++ b/app/src/main/java/com/example/wapapp2/model/ChatDTO.kt
@@ -12,8 +12,6 @@ import java.util.*
 data class ChatDTO(
         @get:Exclude
         var userName: String,
-        @get:Exclude
-        var userId: String,
         @ServerTimestamp
         @PropertyName("sendedTime")
         var sendedTime: Date? = null,
@@ -22,5 +20,5 @@ data class ChatDTO(
         @PropertyName("senderId")
         var senderId: String
 ) : Parcelable {
-        constructor() : this("", "", null, "", "")
+        constructor() : this( "", null, "", "")
 }

--- a/app/src/main/java/com/example/wapapp2/notification/helper/CalcNotificationHelper.kt
+++ b/app/src/main/java/com/example/wapapp2/notification/helper/CalcNotificationHelper.kt
@@ -1,9 +1,12 @@
 package com.example.wapapp2.notification.helper
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.example.wapapp2.R
+import com.example.wapapp2.main.MainActivity
 import com.example.wapapp2.model.FriendDTO
 import com.example.wapapp2.model.ReceiptDTO
 import com.example.wapapp2.model.notifications.NotificationObj

--- a/app/src/main/java/com/example/wapapp2/notification/helper/ChatNotificationHelper.kt
+++ b/app/src/main/java/com/example/wapapp2/notification/helper/ChatNotificationHelper.kt
@@ -1,9 +1,12 @@
 package com.example.wapapp2.notification.helper
 
+import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.app.NotificationCompat
 import com.example.wapapp2.R
+import com.example.wapapp2.main.MainActivity
 import com.example.wapapp2.model.ChatDTO
 import com.example.wapapp2.model.notifications.NotificationObj
 
@@ -21,7 +24,7 @@ class ChatNotificationHelper private constructor(context: Context)
         }
     }
 
-    override fun createNotification(context: Context): NotificationObj {
+    override fun createNotification(context: Context,): NotificationObj {
         val notificationObj = super.createNotification(context)
         notificationObj.notificationBuilder.setSmallIcon(R.mipmap.ic_launcher)
         notificationObj.notificationBuilder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
@@ -30,6 +33,13 @@ class ChatNotificationHelper private constructor(context: Context)
 
     fun notifyNotification(context: Context, roomName: String, chatDTO: ChatDTO) {
         val notificationObj = createNotification(context)
+
+        val intent = Intent(context, MainActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_ONE_SHOT)
+
+        notificationObj.notificationBuilder.setContentIntent(pendingIntent)
+
         val remoteViews = RemoteViews(context.packageName, R.layout.chat_notification_remoteviews)
         remoteViews.setTextViewText(R.id.member_name, chatDTO.userName)
         remoteViews.setTextViewText(R.id.msg, chatDTO.msg)

--- a/app/src/main/java/com/example/wapapp2/repository/ChatRepositorylmpl.kt
+++ b/app/src/main/java/com/example/wapapp2/repository/ChatRepositorylmpl.kt
@@ -6,8 +6,6 @@ import com.example.wapapp2.model.ChatDTO
 import com.example.wapapp2.repository.interfaces.ChatRepository
 import com.google.firebase.firestore.FirebaseFirestore
 import org.json.JSONObject
-import java.io.BufferedReader
-import java.io.InputStreamReader
 import java.io.OutputStream
 import java.net.HttpURLConnection
 import java.net.URL
@@ -43,33 +41,36 @@ class ChatRepositorylmpl private constructor() : ChatRepository {
 
     //  https://firebase.google.com/docs/cloud-messaging/http-server-ref
 
-    fun send(to: List<String>, roomDTO: CalcRoomDTO, chatDTO: ChatDTO) : Int {
+    fun send(tokens : List<String>, roomDTO: CalcRoomDTO, chatDTO: ChatDTO) : Int {
         try {
             //This is not recommended way because anyone can get your API key by using tools like Smali2Java and can send the notification to anyone.
             val apiKey = R.string.Firebase_ApiKey
             val url = URL("https://fcm.googleapis.com/fcm/send")
             val conn: HttpURLConnection = url.openConnection() as HttpURLConnection
-            conn.setDoOutput(true)
-            conn.setRequestMethod("POST")
+            conn.doOutput = true
+            conn.requestMethod = "POST"
             conn.setRequestProperty("Content-Type", "application/json")
             conn.setRequestProperty("Authorization", "key=$apiKey")
 
             val remote_msg = JSONObject()
-            remote_msg.put("registration_ids", to)
+            remote_msg.put("registration_ids", tokens)
             remote_msg.put("priority", "high")
 
             val data = JSONObject()
             data.put("room_name", roomDTO.name)
-            data.put("chatDTO", chatDTO)
+            data.put("chatDTO_username", chatDTO.userName)
+            data.put("chatDTO_msg", chatDTO.msg)
+            data.put("chatDTO_sendedTime", chatDTO.sendedTime)
+            data.put("chatDTO_senderId", chatDTO.senderId)
 
             remote_msg.put("data", data)
 
-            val os: OutputStream = conn.getOutputStream()
+            val os: OutputStream = conn.outputStream
             os.write(remote_msg.toString().toByteArray())
             os.flush()
             os.close()
 
-            return conn.getResponseCode()
+            return conn.responseCode
         } catch (e: Exception) {
             e.printStackTrace()
         }

--- a/app/src/main/java/com/example/wapapp2/repository/ChatRepositorylmpl.kt
+++ b/app/src/main/java/com/example/wapapp2/repository/ChatRepositorylmpl.kt
@@ -1,17 +1,17 @@
 package com.example.wapapp2.repository
 
-import android.widget.Toast
+import com.example.wapapp2.R
 import com.example.wapapp2.model.CalcRoomDTO
 import com.example.wapapp2.model.ChatDTO
 import com.example.wapapp2.repository.interfaces.ChatRepository
-import com.firebase.ui.firestore.FirestoreRecyclerOptions
-import com.firebase.ui.firestore.SnapshotParser
-import com.google.firebase.firestore.DocumentSnapshot
-import com.google.firebase.firestore.EventListener
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.QuerySnapshot
-import java.util.*
-import kotlin.collections.HashMap
+import org.json.JSONObject
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+
 
 class ChatRepositorylmpl private constructor() : ChatRepository {
     private val fireStore = FirebaseFirestore.getInstance()
@@ -38,5 +38,41 @@ class ChatRepositorylmpl private constructor() : ChatRepository {
             .addOnFailureListener { exception ->
                 TODO("전송실패")
             }
+    }
+
+
+    //  https://firebase.google.com/docs/cloud-messaging/http-server-ref
+
+    fun send(to: List<String>, roomDTO: CalcRoomDTO, chatDTO: ChatDTO) : Int {
+        try {
+            //This is not recommended way because anyone can get your API key by using tools like Smali2Java and can send the notification to anyone.
+            val apiKey = R.string.Firebase_ApiKey
+            val url = URL("https://fcm.googleapis.com/fcm/send")
+            val conn: HttpURLConnection = url.openConnection() as HttpURLConnection
+            conn.setDoOutput(true)
+            conn.setRequestMethod("POST")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.setRequestProperty("Authorization", "key=$apiKey")
+
+            val remote_msg = JSONObject()
+            remote_msg.put("registration_ids", to)
+            remote_msg.put("priority", "high")
+
+            val data = JSONObject()
+            data.put("room_name", roomDTO.name)
+            data.put("chatDTO", chatDTO)
+
+            remote_msg.put("data", data)
+
+            val os: OutputStream = conn.getOutputStream()
+            os.write(remote_msg.toString().toByteArray())
+            os.flush()
+            os.close()
+
+            return conn.getResponseCode()
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+        return -1
     }
 }

--- a/app/src/main/java/com/example/wapapp2/service/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/wapapp2/service/MyFirebaseMessagingService.kt
@@ -2,26 +2,41 @@ package com.example.wapapp2.service
 
 import com.example.wapapp2.model.ChatDTO
 import com.example.wapapp2.notification.helper.ChatNotificationHelper
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import java.util.*
 
 class MyFirebaseMessagingService : FirebaseMessagingService() {
 
     /** title = ChatRoomName  **/
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        val title = message.data["room_name"]
-        val chatDTO = message.data["chatDTO"] as ChatDTO
-    }
-
-    override fun onMessageSent(msgId: String) {
-        super.onMessageSent(msgId)
+        val data = message.data
+        val chatDTO : ChatDTO?
+        val room = data["room_name"]?.let{
+            chatDTO = ChatDTO(
+                data["chatDTO_username"]!!,
+                Date(),
+                data["chatDTO_sendedTime"]!!,
+                data["chatDTO_senderId"]!!
+            )
+        }
     }
 
     /** 토큰 생성시 서버에 등록 과정 필요 **/
     override fun onNewToken(token: String) {
         super.onNewToken(token)
         //토큰 등록
+
+        FirebaseAuth.getInstance().currentUser?.let {
+            FirebaseFirestore.getInstance()
+                .collection("users")
+                .document(it.uid)
+                .collection("FCM_TOKEN")
+                .document().set(token)
+        }
     }
 
 

--- a/app/src/main/java/com/example/wapapp2/service/MyFirebaseMessagingService.kt
+++ b/app/src/main/java/com/example/wapapp2/service/MyFirebaseMessagingService.kt
@@ -1,0 +1,32 @@
+package com.example.wapapp2.service
+
+import com.example.wapapp2.model.ChatDTO
+import com.example.wapapp2.notification.helper.ChatNotificationHelper
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+
+class MyFirebaseMessagingService : FirebaseMessagingService() {
+
+    /** title = ChatRoomName  **/
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        val title = message.data["room_name"]
+        val chatDTO = message.data["chatDTO"] as ChatDTO
+    }
+
+    override fun onMessageSent(msgId: String) {
+        super.onMessageSent(msgId)
+    }
+
+    /** 토큰 생성시 서버에 등록 과정 필요 **/
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        //토큰 등록
+    }
+
+
+    private fun sendNotification(title : String ,chatDTO: ChatDTO) {
+        val notificationBuilder = ChatNotificationHelper.getINSTANCE(this)
+            .notifyNotification(this, title , chatDTO)
+    }
+}

--- a/app/src/main/java/com/example/wapapp2/view/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/example/wapapp2/view/chat/ChatAdapter.kt
@@ -14,7 +14,7 @@ import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.format.ISODateTimeFormat
 
-class ChatAdapter(val myId: String, option : FirestoreRecyclerOptions<ChatDTO>) : FirestoreRecyclerAdapter<ChatDTO, RecyclerView.ViewHolder>(option) {
+class ChatAdapter(val myId: String, option : FirestoreRecyclerOptions<ChatDTO>, val scrollListener: ScrollListener) : FirestoreRecyclerAdapter<ChatDTO, RecyclerView.ViewHolder>(option){
     private val timeFormat = DateTimeFormat.forPattern("a hh:mm")
     private val dateTimeParser = ISODateTimeFormat.dateTimeParser()
 
@@ -73,6 +73,7 @@ class ChatAdapter(val myId: String, option : FirestoreRecyclerOptions<ChatDTO>) 
 
     override fun onDataChanged() {
         super.onDataChanged()
+        scrollListener.ScrollToBottom()
     }
 
 }

--- a/app/src/main/java/com/example/wapapp2/view/chat/ChatFragment.kt
+++ b/app/src/main/java/com/example/wapapp2/view/chat/ChatFragment.kt
@@ -71,7 +71,7 @@ class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment(), ScrollListener {
     private fun setInputListener() {
         binding.sendBtn.setOnClickListener {
             if (binding.textInputEditText.text!!.isNotEmpty()) {
-                val newChat = ChatDTO(myAccountViewModel.myName  ,myAccountViewModel.myAccountId, Date(),binding.textInputLayout.editText!!.text.toString(),myAccountViewModel.myAccountId)
+                val newChat = ChatDTO(myAccountViewModel.myName  ,Date(),binding.textInputLayout.editText!!.text.toString(),myAccountViewModel.myAccountId)
                 binding.textInputLayout.editText!!.text.clear()
                 chatViewModel.sendMsg(newChat)
                 binding.chatList.smoothScrollToPosition(chatAdapter_.snapshots.size)

--- a/app/src/main/java/com/example/wapapp2/view/chat/ChatFragment.kt
+++ b/app/src/main/java/com/example/wapapp2/view/chat/ChatFragment.kt
@@ -19,7 +19,7 @@ import com.example.wapapp2.viewmodel.ChatViewModel
 import com.example.wapapp2.viewmodel.MyAccountViewModel
 import java.util.*
 
-class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment() {
+class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment(), ScrollListener {
     private lateinit var binding: FragmentChatBinding
 
     private lateinit var chatAdapter_: ChatAdapter
@@ -37,7 +37,7 @@ class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         myAccountViewModel = ViewModelProvider(requireActivity())[MyAccountViewModel::class.java]
-        chatAdapter_ = ChatAdapter(myAccountViewModel.myAccountId, chatViewModel.getOptions(calcRoomDTO))
+        chatAdapter_ = ChatAdapter(myAccountViewModel.myAccountId, chatViewModel.getOptions(calcRoomDTO),this@ChatFragment::ScrollToBottom)
         bundle = (arguments ?: savedInstanceState) as Bundle
     }
 
@@ -48,9 +48,6 @@ class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment() {
         binding.chatList.apply {
             layoutManager = LinearLayoutManager(requireActivity(), LinearLayoutManager.VERTICAL, false)
             this.adapter = chatAdapter_
-            //scroll for last message
-            //this.smoothScrollToPosition(chatAdapter_.itemCount -1)
-
         }
         setInputListener()
 
@@ -77,6 +74,7 @@ class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment() {
                 val newChat = ChatDTO(myAccountViewModel.myName  ,myAccountViewModel.myAccountId, Date(),binding.textInputLayout.editText!!.text.toString(),myAccountViewModel.myAccountId)
                 binding.textInputLayout.editText!!.text.clear()
                 chatViewModel.sendMsg(newChat)
+                binding.chatList.smoothScrollToPosition(chatAdapter_.snapshots.size)
                 // 전송
             } else {
                 Toast.makeText(requireContext(), "메시지를 입력해주세요!", Toast.LENGTH_SHORT).show()
@@ -93,6 +91,10 @@ class ChatFragment(val calcRoomDTO : CalcRoomDTO) : Fragment() {
     override fun onStop() {
         chatAdapter_.stopListening()
         super.onStop()
+    }
+
+    override fun ScrollToBottom() {
+        binding.chatList.smoothScrollToPosition(chatAdapter_.snapshots.size)
     }
 
 }

--- a/app/src/main/java/com/example/wapapp2/view/chat/ScrollListener.kt
+++ b/app/src/main/java/com/example/wapapp2/view/chat/ScrollListener.kt
@@ -1,0 +1,5 @@
+package com.example.wapapp2.view.chat
+
+fun interface ScrollListener {
+    fun ScrollToBottom()
+}

--- a/app/src/main/java/com/example/wapapp2/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/com/example/wapapp2/viewmodel/ChatViewModel.kt
@@ -42,7 +42,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         val recyclerOption = FirestoreRecyclerOptions.Builder<ChatDTO>()
             .setQuery(query, SnapshotParser {
                 //id로부터 사람이름
-                ChatDTO(it.getString("userName").toString() , it.id , it.getTimestamp("sendedTime")?.toDate(),it.getString("msg").toString(),it.getString("senderId").toString())
+                ChatDTO(it.getString("userName").toString() , it.getTimestamp("sendedTime")?.toDate(),it.getString("msg").toString(),it.getString("senderId").toString())
             })
             .build()
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -94,4 +94,7 @@
     <string name="empty_my_friends">친구 목록이 비어있습니다</string>
     <string name="empty_receipts">정산 내역이 없습니다</string>
     <string name="no_search_results_found">검색 결과가 없습니다</string>
+    
+    
+    <string name="Firebase_ApiKey"></string>
 </resources>


### PR DESCRIPTION
- **API_KEY를 저장해 FCM 사용에 쓰이는 방식으로 구현**  (보안에 취약)
- **user document들에 token collection 생성 후 token 정보 저장**

------

service로 FCM을 받을 수 있는 환경은 만들어 놓았습니다.

Firebase Function을 못 쓰는 상황에서는 Firebase-APIKEY를 package 내부에 저장해 놓고 http로 전송하는 방식밖에 찾지 못하였어서 string에 값이 빈 apikey를 넣어 둠으로써 방식만 갖추어 놓은 상태입니다.

user collection의 document마다 token collection을 생성하여 사용자의 토큰을 저장한 후에 대화방 참여자들의 정보에 매칭시켜 메시지가 전송될 때 registered_ids의 값에 저장하여 FCM을 쏘는 방식으로 계획중입니다.

채팅 전송을 위해 chatRoomDTO가 필요하기 때문에 #50 을 우선적으로 진행하도록 하겠습니다.